### PR TITLE
Handle exceptions around address caching

### DIFF
--- a/lib/Dojah.js
+++ b/lib/Dojah.js
@@ -310,17 +310,18 @@ const Dojah = ({
               '@Dojah:SESSION_ID',
               data.data.verificationId,
             );
-
-            const addressLocation =
-              widgetData.address.data.location.addressLocation;
-            await AsyncStorage.setItem(
-              '@Dojah:LATITUDE',
-              addressLocation.latitude,
-            );
-            await AsyncStorage.setItem(
-              '@Dojah:LONGITUDE',
-              addressLocation.longitude,
-            );
+            
+            try{
+              const addressLocation =
+                widgetData.address.data.location.addressLocation;
+              await AsyncStorage.setItem(
+                '@Dojah:LATITUDE',
+                addressLocation.latitude,
+              );
+              await AsyncStorage.setItem(
+                '@Dojah:LONGITUDE',
+                addressLocation.longitude,
+              );}catch(e){}
           }
 
           response(data.type, data);


### PR DESCRIPTION
The following code below would raise a problem if verification was a success, but address verification wasn't requested. An easy fix is to contain the undefined exception in try catch.    
const addressLocation =
                widgetData.address.data.location.addressLocation;
              await AsyncStorage.setItem(
                '@Dojah:LATITUDE',
                addressLocation.latitude,
              );
              await AsyncStorage.setItem(
                '@Dojah:LONGITUDE',
                addressLocation.longitude,
              );