### PR TITLE
Urgent (added stringify verificationId) to fixed current production bug

### DIFF
--- a/lib/Dojah.js
+++ b/lib/Dojah.js
@@ -307,7 +307,7 @@ const Dojah = ({
 
             await AsyncStorage.setItem(
               '@Dojah:SESSION_ID',
-              JSON.stringify(data.data.verificationId),
+              `${data.data.verificationId}`,
             );
 
             try {

--- a/lib/Dojah.js
+++ b/lib/Dojah.js
@@ -307,7 +307,7 @@ const Dojah = ({
 
             await AsyncStorage.setItem(
               '@Dojah:SESSION_ID',
-              data.data.verificationId,
+              JSON.stringify(data.data.verificationId),
             );
 
             try {


### PR DESCRIPTION
JSON.stringify(data.data.verificationId),

Added stringify verificationId) to fixed current production bug.

WARN  [AsyncStorage] The value for key "@Dojah:SESSION_ID" is not a string. This can lead to unexpected behavior/errors. Consider stringifying it.
Passed value: 83370
Passed key: @Dojah:SESSION_ID
 WARN  Possible Unhandled Promise Rejection (id: 1):
Error: java.lang.Double cannot be cast to java.lang.String
Error: java.lang.Double cannot be cast to java.lang.String
