### PR TITLE
fix: liveness feat opening video instead of selfie

### DIFF
--- a/lib/Dojah.js
+++ b/lib/Dojah.js
@@ -345,7 +345,7 @@ const Dojah = ({
         useWebkit={true}
         startInLoadingState={true}
         androidLayerType="hardware"
-        allowsInlineMediaPlayback={needsCamera}
+        allowsInlineMediaPlayback={false}
         geolocationEnabled={needsLocation}
       />
     </View>


### PR DESCRIPTION
While using this package, I noticed the recent changes on iOS 17 led to the liveness feature being broken for IOS device. The way I fixed it was by setting the allowsInlineMediaPlayback={false}